### PR TITLE
Update influxdb.h

### DIFF
--- a/src/influxdb.h
+++ b/src/influxdb.h
@@ -39,7 +39,7 @@ void Influxdb_postData() {
   poststring.concat(live.l.lI /100.f);
   poststring.concat(F("\nLoad-Watt value="));
   poststring.concat(live.l.lP /100.f);
-  poststring.concat(F("\nDevice temp value="));
+  poststring.concat(F("\nDevice-temp value="));
   poststring.concat(deviceTemp/100.0f);
   poststring.concat(F("\nBattery-Current value="));
   poststring.concat(batteryCurrent/100.f);


### PR DESCRIPTION
Fix Device-temp value in influxdb.h

The hyphen missing caused an issue with me storing retrieving the device-temp value from the influx DB. This appeared to fix the issue, and keeps with the coding style of the rest of the project.

Apologies if I have made a mistake with this pull request, this is my first one!